### PR TITLE
added hint for joysticks to stablize sixaxis & dualshock controllers

### DIFF
--- a/test/testgamecontroller.c
+++ b/test/testgamecontroller.c
@@ -530,6 +530,7 @@ main(int argc, char *argv[])
     SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE, "1");
     SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE, "1");
     SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
+    SDL_SetHint(SDL_HINT_LINUX_JOYSTICK_DEADZONES, "1");
 
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);


### PR DESCRIPTION
Added a SDL_SetHint(SDL_HINT_LINUX_JOYSTICK_DEADZONES, "1"); so that playstation controllers can be tested properly.

## Description
While testing Playstation controllers one will run into an issue with analog stick deadzone & they may be polled without any interaction. This hinet has been added so that this test program shaking in the deadzone was filtered by SDL before reaching the program.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
